### PR TITLE
Bugfix: Make -copy-history-url work with '%'s in url

### DIFF
--- a/eww-history-ext.el
+++ b/eww-history-ext.el
@@ -174,8 +174,8 @@
   (interactive)
   (if-let ((url (eww-history-ext--get-url)))
       (progn
-        (message url)
-        (kill-new url))
+	(kill-new url)
+        (message "Copied %s to kill ring" url))
     (user-error "There is no history at point")))
 
 (defun eww-history-ext-copy-history-title ()


### PR DESCRIPTION
Modify to be similar to eww-copy-alternate-url.